### PR TITLE
Add total row in resumo estoque

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -568,10 +568,17 @@ async function loadResumoEstoque(filtro = 'modelo') {
             if (data.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="2" class="empty-state"><i class="fas fa-chart-bar"></i><br>Nenhum dado encontrado</td></tr>';
             } else {
+                let totalGeral = 0;
                 data.forEach(item => {
                     const row = createResumoRow(item, filtro);
                     tbody.appendChild(row);
+                    totalGeral += item.total;
                 });
+
+                const totalRow = document.createElement('tr');
+                totalRow.classList.add('total-row');
+                totalRow.innerHTML = `<td>Total Geral</td><td>${totalGeral}</td>`;
+                tbody.appendChild(totalRow);
             }
         } else {
             showToast(data.error || 'Erro ao carregar resumo', 'error');

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -803,6 +803,17 @@ table tr:hover td {
     font-weight: bold;
 }
 
+/* Linha total no resumo de estoque */
+.total-row td {
+    font-weight: bold;
+    background: #f8f9fa;
+}
+
+body.dark-mode .total-row td {
+    background: #333;
+    color: #f5f5f5;
+}
+
 /* Dark Mode */
 body.dark-mode {
     background-color: #121212;


### PR DESCRIPTION
## Summary
- summarize model/operator totals with a final row
- style the new total row in light and dark modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2f6c1f648320bab93635a31759f5