### PR TITLE
Remove deprecated month filter

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -286,10 +286,6 @@
                         <select id="filtro-operador"></select>
                     </div>
                     <div class="form-group">
-                        <label for="filtro-mes">Mês</label>
-                        <input type="month" id="filtro-mes">
-                    </div>
-                    <div class="form-group">
                         <label for="filtro-dia">Dia</label>
                         <input type="date" id="filtro-dia">
                     </div>

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -1113,14 +1113,11 @@ function handleFiltrarEstoque() {
 
 function handleFiltrarConfig() {
     const operador = document.getElementById('filtro-operador').value;
-    const mes = document.getElementById('filtro-mes').value;
     const dia = document.getElementById('filtro-dia').value;
     if (operador && dia) {
         loadResumoConfig(operador, null, dia);
-    } else if (operador && mes) {
-        const [ano, mesNum] = mes.split('-');
-        const mesAno = `${mesNum}/${ano}`;
-        loadResumoConfig(operador, mesAno);
+    } else if (operador) {
+        loadResumoConfig(operador);
     }
 }
 


### PR DESCRIPTION
## Summary
- drop Month filter field from historic config filters
- update filter logic to work without month input

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d07fa85188320a819df4d13f07a94