### PR TITLE
Remove zero-record summary

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -560,7 +560,10 @@ async function loadResumoConfig(operador, mesAno = null, dia = null) {
 
         if (response.ok) {
             const resumoDiv = document.getElementById('historico-config-resumo');
-            if (dia) {
+
+            if (data.total === 0) {
+                resumoDiv.textContent = '';
+            } else if (dia) {
                 const [ano, mes, diaNum] = dia.split('-');
                 resumoDiv.textContent = `No dia ${diaNum}/${mes}/${ano} o Operador ${operador}, configurou ${data.total} rastreadores`;
             } else if (mesAno) {


### PR DESCRIPTION
## Summary
- hide the configuration summary when there are no configuration entries

## Testing
- `python -m py_compile src/static/script.js` *(fails: SyntaxError because Python attempted to parse JavaScript)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e616a40832089a825d3b699309b