### PR TITLE
Adjust dashboard for monthly exits

### DIFF
--- a/DOCUMENTACAO_COMPLETA.md
+++ b/DOCUMENTACAO_COMPLETA.md
@@ -144,7 +144,7 @@ O sistema implementa dois tipos distintos de acesso que determinam quais funcion
 
 O dashboard principal fornece uma visão consolidada das métricas mais importantes do sistema, apresentadas através de cartões informativos com design moderno e cores que facilitam a interpretação rápida das informações. O cartão de "Total em Estoque" apresenta a quantidade total de dispositivos rastreadores disponíveis no inventário, calculada em tempo real baseada em todas as movimentações registradas no sistema.
 
-O cartão de "Movimentações do Mês" mostra o número total de transações de entrada e saída processadas no mês atual, fornecendo uma indicação da atividade operacional do sistema. Esta métrica é útil para gestores acompanharem tendências de movimentação e identificarem períodos de maior ou menor atividade.
+O cartão de "Total de Saídas" exibe a soma de todos os rastreadores que deixaram o estoque no mês atual. Essa métrica reinicia automaticamente a cada virada de mês, permitindo acompanhar com facilidade a quantidade de dispositivos expedidos no período.
 
 O cartão de "Colaboradores Ativos" apresenta a quantidade de configuradores atualmente ativos no sistema, incluindo apenas usuários com status ativo e tipo de acesso configurador. Esta informação é importante para planejamento de capacidade e distribuição de trabalho entre a equipe de configuração.
 

--- a/src/routes/rastreador.py
+++ b/src/routes/rastreador.py
@@ -38,13 +38,14 @@ def get_dashboard():
         # Total em estoque
         total_estoque = db.session.query(func.sum(Estoque.quantidade_estoque)).scalar() or 0
         
-        # Movimentações do mês atual
+        # Total de saídas do mês atual
         hoje = date.today()
         primeiro_dia_mes = hoje.replace(day=1)
-        movimentacoes_mes = Movimentacao.query.filter(
+        saidas_mes = db.session.query(func.sum(Movimentacao.quantidade)).filter(
             Movimentacao.data >= primeiro_dia_mes,
-            Movimentacao.data <= hoje
-        ).count()
+            Movimentacao.data <= hoje,
+            Movimentacao.tipo == 'Saída'
+        ).scalar() or 0
         
         # Total de rastreadores configurados no mês
         rastreadores_configurados = db.session.query(func.sum(ConfiguracaoDiaria.quantidade)).filter(
@@ -59,7 +60,7 @@ def get_dashboard():
         
         return jsonify({
             'total_estoque': total_estoque,
-            'movimentacoes_mes': movimentacoes_mes,
+            'saidas_mes': saidas_mes,
             'rastreadores_configurados': rastreadores_configurados,
             'ultimas_movimentacoes': [mov.to_dict() for mov in ultimas_movimentacoes]
         }), 200

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -104,10 +104,10 @@
                         </div>
                     </div>
                     <div class="card">
-                        <i class="card-icon fas fa-exchange-alt"></i>
+                        <i class="card-icon fas fa-sign-out-alt"></i>
                         <div class="card-content">
-                            <h3>Movimentações do Mês</h3>
-                            <div class="card-number" id="movimentacoes-mes">0</div>
+                            <h3>Total de Saídas</h3>
+                            <div class="card-number" id="saidas-mes">0</div>
                         </div>
                     </div>
                     <div class="card">

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -389,7 +389,7 @@ async function loadDashboard() {
 
         if (response.ok) {
             document.getElementById('total-estoque').textContent = data.total_estoque;
-            document.getElementById('movimentacoes-mes').textContent = data.movimentacoes_mes;
+            document.getElementById('saidas-mes').textContent = data.saidas_mes;
             document.getElementById('rastreadores-configurados').textContent = data.rastreadores_configurados;
 
             // Carregar últimas movimentações


### PR DESCRIPTION
## Summary
- replace monthly moves metric with monthly exit count
- update frontend to display **Total de Saídas** on the dashboard
- document new card behaviour in `DOCUMENTACAO_COMPLETA.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e6a933da88320aa3a75dd690980cf