### PR TITLE
Add type filter for movement history

### DIFF
--- a/src/routes/rastreador.py
+++ b/src/routes/rastreador.py
@@ -499,12 +499,16 @@ def get_historico_movimentacoes():
     try:
         data_str = request.args.get('data')
         mes_ano = request.args.get('mesAno')
+        tipo = request.args.get('tipo')
         query = HistoricoMovimentacao.query
         if data_str:
             filtro_data = datetime.strptime(data_str, '%Y-%m-%d').date()
             query = query.filter_by(data=filtro_data)
         elif mes_ano:
             query = query.filter_by(mes_ano=mes_ano)
+
+        if tipo and tipo != 'Todos':
+            query = query.filter_by(tipo=tipo)
 
         historico = query.order_by(desc(HistoricoMovimentacao.data)).all()
         return jsonify([mov.to_dict() for mov in historico]), 200

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -220,6 +220,14 @@
                         <label for="filtro-data">Filtrar por Data</label>
                         <input type="date" id="filtro-data">
                     </div>
+                    <div class="form-group">
+                        <label for="filtro-tipo">Tipo</label>
+                        <select id="filtro-tipo">
+                            <option value="Todos">Todos</option>
+                            <option value="Entrada">Entrada</option>
+                            <option value="Saída">Saída</option>
+                        </select>
+                    </div>
                     <button id="filtrar-historico-btn" class="btn btn-secondary">
                         <i class="fas fa-filter"></i> Filtrar
                     </button>

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -450,12 +450,20 @@ async function loadMovimentacoes() {
     }
 }
 
-async function loadHistoricoMovimentacoes(dataFiltro = '') {
+async function loadHistoricoMovimentacoes(dataFiltro = '', tipoFiltro = 'Todos') {
     try {
         showLoading();
         let url = `${API_BASE}/historico-movimentacoes`;
+        const params = new URLSearchParams();
         if (dataFiltro) {
-            url += `?data=${encodeURIComponent(dataFiltro)}`;
+            params.append('data', dataFiltro);
+        }
+        if (tipoFiltro && tipoFiltro !== 'Todos') {
+            params.append('tipo', tipoFiltro);
+        }
+        const queryString = params.toString();
+        if (queryString) {
+            url += `?${queryString}`;
         }
 
         const response = await fetch(url, {
@@ -1113,11 +1121,8 @@ async function handleSalvarHistorico() {
 
 function handleFiltrarHistorico() {
     const data = document.getElementById('filtro-data').value;
-    if (data) {
-        loadHistoricoMovimentacoes(data);
-    } else {
-        loadHistoricoMovimentacoes();
-    }
+    const tipo = document.getElementById('filtro-tipo').value;
+    loadHistoricoMovimentacoes(data, tipo);
 }
 
 function handleFiltrarResumo() {


### PR DESCRIPTION
## Summary
- add `filtro-tipo` select to movement history filters
- support optional `tipo` param in JS for history loading
- handle new filter in backend route

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687132a2bba88320a915c0235e336d1f